### PR TITLE
bosch_rawscan_cli IVT HTTP bug fixes

### DIFF
--- a/bosch_thermostat_client/bosch_rawscan_cli.py
+++ b/bosch_thermostat_client/bosch_rawscan_cli.py
@@ -59,8 +59,8 @@ async def cli(ctx, host: str, token: str, password: str, protocol: str, device: 
             await scan(gateway, smallscan, output, stdout)
     elif protocol.upper() == HTTP and device.upper() == IVT:
         async with aiohttp.ClientSession() as session:
-            _LOGGER.debug("Connecting to %s with token '%s' and password '%s'", ip, token, password)
-            gateway = BoschGateway(session=asyncio.get_event_loop(),
+            _LOGGER.debug("Connecting to %s with token '%s' and password '%s'", host, token, password)
+            gateway = BoschGateway(session=session,
                                    session_type=HTTP,
                                    host=host,
                                    access_token=token,


### PR DESCRIPTION
This PR fixes two bugs:

```
$ python3 bosch_rawscan_cli.py --host 1.2.3.4 --token "foo-bar" --password "barfoo" --protocol HTTP --device IVT
Traceback (most recent call last):
  File "bosch_rawscan_cli.py", line 94, in <module>
    asyncio.get_event_loop().run_until_complete(cli())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1236, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "bosch_rawscan_cli.py", line 18, in wrapper
    return asyncio.run(f(*args, **kwargs))
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "bosch_rawscan_cli.py", line 62, in cli
    _LOGGER.debug("Connecting to %s with token '%s' and password '%s'", ip, token, password)
NameError: name 'ip' is not defined
```

```
$ python3 bosch_rawscan_cli.py --host 1.2.3.4 --token "foo-bar" --password "barfoo" --protocol HTTP --device IVT
Traceback (most recent call last):
  File "bosch_rawscan_cli.py", line 94, in <module>
    asyncio.get_event_loop().run_until_complete(cli())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1236, in invoke
    return Command.invoke(self, ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "bosch_rawscan_cli.py", line 18, in wrapper
    return asyncio.run(f(*args, **kwargs))
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "bosch_rawscan_cli.py", line 69, in cli
    if await gateway.check_connection():
  File "/Users/slovdahl/dev/private/bosch-thermostat-client-python/bosch_thermostat_client/gateway/base_gateway.py", line 228, in check_connection
    await self.initialize()
  File "/Users/slovdahl/dev/private/bosch-thermostat-client-python/bosch_thermostat_client/gateway/base_gateway.py", line 61, in initialize
    await self._update_info(initial_db.get(GATEWAY))
  File "/Users/slovdahl/dev/private/bosch-thermostat-client-python/bosch_thermostat_client/gateway/ivt_gateway.py", line 57, in _update_info
    response = await self._connector.get(uri)
  File "/Users/slovdahl/dev/private/bosch-thermostat-client-python/bosch_thermostat_client/connectors/http.py", line 78, in get
    self._websession.get,
AttributeError: '_UnixSelectorEventLoop' object has no attribute 'get'
```