### PR TITLE
Add RoomTemperature Sensor to CAN HCX

### DIFF
--- a/bosch_thermostat_client/db/can.json
+++ b/bosch_thermostat_client/db/can.json
@@ -102,6 +102,10 @@
                     "id": "holidayMode/activated",
                     "name": "Holiday Mode Activated"
                 },
+                "roomtemperature": {
+                    "id": "roomtemperature",
+                    "name": "Room temperature"
+                },
                 "supplyTemperatureSetpoint": {
                     "id": "supplyTemperatureSetpoint",
                     "name": "Supply temperature setpoint"


### PR DESCRIPTION
Hi,

Thanks for a very nice implementation! I was able to successfully connect my KM200 into HomeAssistant via your [component](https://github.com/bosch-thermostat/home-assistant-bosch-custom-component). There was however one sensor missing. I have Buderus HRC2 as a room regulator connected to CAN bus and the room temperature sensor was missing. This pull request fixes it.

I can also provide bosch scan dump if needed.