### PR TITLE
Add 'totalWorkingTime' (/heatSources/workingTime/totalSystem) field support for CT200

### DIFF
--- a/bosch_thermostat_client/db/easycontrol/031200.json
+++ b/bosch_thermostat_client/db/easycontrol/031200.json
@@ -260,6 +260,10 @@
             "id": "/heatSources/returnTemperature",
             "name": "Return temperature"
         },
+        "totalWorkingTime": {
+            "id": "/heatSources/workingTime/totalSystem",
+            "name": "Total working time"
+        },
         "refillNeeded": {
             "id": "/heatSources/refillNeeded",
             "name": "Refill needed11"


### PR DESCRIPTION
Example data: 
{
      "id": "/heatSources/workingTime/totalSystem",
      "type": "floatValue",
      "writeable": 0,
      "recordable": 0,
      "value": 151538.0,
      "used": "true",
      "available": "true",
      "unitOfMeasure": "mins",
      "minValue": 0.0,
      "maxValue": 16777215.0,
      "stepSize": 1.0
}