### PR TITLE
Add 'heatingCircuits' with 'supplyTemperatureSetpoint' field support for CT200

### DIFF
--- a/bosch_thermostat_client/db/easycontrol/031200.json
+++ b/bosch_thermostat_client/db/easycontrol/031200.json
@@ -209,6 +209,14 @@
 
         }
     },
+    "heatingCircuits": {
+        "sensors": {
+            "supplyTemperatureSetpoint": {
+                "id": "supplyTemperatureSetpoint",
+                "name": "Supply Temperature Setpoint"
+            }        
+        }
+    },
     "sensors": {
         "outdoor_t1": {
             "id": "/system/sensors/temperatures/outdoor_t1",


### PR DESCRIPTION
Example data: 

    {
      "id": "/heatingCircuits/hc1/supplyTemperatureSetpoint",
      "type": "floatValue",
      "writeable": 0,
      "recordable": 0,
      "value": 28,
      "used": "true",
      "available": "true",
      "unitOfMeasure": "C",
      "minValue": 5,
      "maxValue": 90,
      "stepSize": 1
    },