### PR TITLE
new feature: specifiy --path multiple times

### DIFF
--- a/bosch_thermostat_client/bosch_cli.py
+++ b/bosch_thermostat_client/bosch_cli.py
@@ -63,7 +63,6 @@ async def _scan(gateway, smallscan, output, stdout):
 async def _runquery(gateway, path):
     _LOGGER.debug("Trying to connect to gateway.")
     result = await gateway.raw_query(path)
-    _LOGGER.info("Query succeed: %s", path)
     click.secho(json.dumps(result, indent=4, sort_keys=True), fg="green")
 
 
@@ -254,7 +253,8 @@ _path_options = [
         "--path",
         type=str,
         required=True,
-        help="Path to run against. Look at rawscan at possible paths. e.g. /gateway/uuid",
+        multiple=True,
+        help="Path to run against. Look at rawscan at possible paths. e.g. /gateway/uuid - Can be specified multiple times!",
     )
 ]
 
@@ -271,7 +271,7 @@ async def query(
     password: str,
     protocol: str,
     device: str,
-    path: str,
+    path: list[str],
     debug: int,
 ):
     """Query values of Bosch thermostat."""

--- a/bosch_thermostat_client/gateway/base.py
+++ b/bosch_thermostat_client/gateway/base.py
@@ -338,11 +338,15 @@ class BaseGateway:
         return self.uuid
 
     async def raw_query(self, path):
+        rawlist = []
         """Run RAW query like /gateway/uuid."""
         try:
-            return await self._connector.get(path)
+            for uri in path:
+                _LOGGER.info(f"Scanning {uri}")
+                rawlist.append(await self._connector.get(uri))
         except DeviceException as err:
             _LOGGER.error(err)
+        return rawlist
 
     async def raw_put(self, path: str, value: Any) -> None:
         """Run RAW PUT."""


### PR DESCRIPTION
Add the possibility to specify --path multiple times.

I am interested in 11 different parameters of my CT200. Right now I have to execute 3 rawscans to retrieve all possible data (basically everything but not recordings which takes awfully long to retrieve) - but all I need are those 11 parameters - all the other read out parameters are discarded.

It would be much better if there would be a way only requesting the parameters I need.

With that change it can now be achived by specifying all the path of interest.

Thats why I enhanced the parameters to allow multiple specification of the path parameter. For example:

```
olli@patna bosch-thermostat-client-python> python3.11 bosch_thermostat_client/bosch_cli.py query --host <retracted> --token <retracted> --password <retracted> --protocol HTTP --device IVT --path /system/sensors/temperatures/supply_t1 --path /heatingCircuits/hc1/roomtemperature --path /system/sensors/temperatures/outdoor_t1
2023-04-16 00:02:36 INFO (MainThread) [__main__] Connecting to <retracted> with 'HTTP'
2023-04-16 00:02:36 INFO (MainThread) [bosch_thermostat_client.gateway.base] Scanning /system/sensors/temperatures/supply_t1
2023-04-16 00:02:36 INFO (MainThread) [bosch_thermostat_client.gateway.base] Scanning /heatingCircuits/hc1/roomtemperature
2023-04-16 00:02:36 INFO (MainThread) [bosch_thermostat_client.gateway.base] Scanning /system/sensors/temperatures/outdoor_t1
[
    {
        "id": "/system/sensors/temperatures/supply_t1",
        "recordable": 0,
        "state": [
            {
                "open": -3276.8
            },
            {
                "short": 3276.7
            }
        ],
        "type": "floatValue",
        "unitOfMeasure": "C",
        "value": 24.4,
        "writeable": 0
    },
    {
        "id": "/heatingCircuits/hc1/roomtemperature",
        "recordable": 1,
        "state": [
            {
                "open": -3276.8
            },
            {
                "short": 3276.7
            }
        ],
        "type": "floatValue",
        "unitOfMeasure": "C",
        "value": 21.2,
        "writeable": 0
    },
    {
        "id": "/system/sensors/temperatures/outdoor_t1",
        "recordable": 1,
        "state": [
            {
                "open": -3276.8
            },
            {
                "short": 3276.7
            }
        ],
        "type": "floatValue",
        "unitOfMeasure": "C",
        "value": 6.4,
        "writeable": 0
    }
]
olli@patna bosch-thermostat-client-python>
```