### PR TITLE
new feature: support for reading parameters from a config file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "colorlog>=6.7.0",
     "pyaes>=1.6.1",
     "pytz>=2023.3",
+    "pyyaml>=6.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Add an `--config` option where a config YAML file can be specified (default: config.yml in current directory). That YAML file can look like:

```
# cat config.yml
token: whatever
password: secret
host: <ip>
protocol: HTTP
device: IVT
```

Then you can call the client without specifying those parameters in the cmdline (or you can, then overriding the ones in config.yml)
```
# python3.11 bosch_thermostat_client/bosch_cli.py query --path /system/sensors/temperatures/supply_t1
2023-04-16 15:27:53 INFO (MainThread) [__main__] Connecting to <ip> with 'HTTP'
2023-04-16 15:27:53 INFO (MainThread) [bosch_thermostat_client.gateway.base] Scanning /system/sensors/temperatures/supply_t1
[
    {
        "id": "/system/sensors/temperatures/supply_t1",
        "recordable": 0,
        "state": [
            {
                "open": -3276.8
            },
            {
                "short": 3276.7
            }
        ],
        "type": "floatValue",
        "unitOfMeasure": "C",
        "value": 79.5,
        "writeable": 0
    }
]
```

It uses PyYAML which is already a dependency of "bandit" - so no additional package gets installed.