### PR TITLE
CT200: Move dhw1 openWindowDetectionStatus to zone circuit

### DIFF
--- a/bosch_thermostat_client/db/easycontrol/031302.json
+++ b/bosch_thermostat_client/db/easycontrol/031302.json
@@ -265,10 +265,6 @@
       "hotWaterSystem": {
         "id": "hotWaterSystem",
         "name": "hotWaterSystem"
-      },
-      "openWindowDetectionStatus": {
-        "id": "openWindowDetection/status",
-        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/031302.json
+++ b/bosch_thermostat_client/db/easycontrol/031302.json
@@ -134,6 +134,10 @@
         "name": "humidity",
         "state_class": "measurement",
         "device_class": "humidity"
+      },
+      "openWindowDetectionStatus": {
+        "id": "openWindowDetection/status",
+        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040000.json
+++ b/bosch_thermostat_client/db/easycontrol/040000.json
@@ -187,6 +187,10 @@
         "name": "humidity",
         "state_class": "measurement",
         "device_class": "humidity"
+      },
+      "openWindowDetectionStatus": {
+        "id": "openWindowDetection/status",
+        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040000.json
+++ b/bosch_thermostat_client/db/easycontrol/040000.json
@@ -318,10 +318,6 @@
       "hotWaterSystem": {
         "id": "hotWaterSystem",
         "name": "hotWaterSystem"
-      },
-      "openWindowDetectionStatus": {
-        "id": "openWindowDetection/status",
-        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040200.json
+++ b/bosch_thermostat_client/db/easycontrol/040200.json
@@ -187,6 +187,10 @@
         "name": "humidity",
         "state_class": "measurement",
         "device_class": "humidity"
+      },
+      "openWindowDetectionStatus": {
+        "id": "openWindowDetection/status",
+        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040200.json
+++ b/bosch_thermostat_client/db/easycontrol/040200.json
@@ -318,10 +318,6 @@
       "hotWaterSystem": {
         "id": "hotWaterSystem",
         "name": "hotWaterSystem"
-      },
-      "openWindowDetectionStatus": {
-        "id": "openWindowDetection/status",
-        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040201.json
+++ b/bosch_thermostat_client/db/easycontrol/040201.json
@@ -187,6 +187,10 @@
         "name": "humidity",
         "state_class": "measurement",
         "device_class": "humidity"
+      },
+      "openWindowDetectionStatus": {
+        "id": "openWindowDetection/status",
+        "name": "openWindowDetection Status"
       }
     }
   },

--- a/bosch_thermostat_client/db/easycontrol/040201.json
+++ b/bosch_thermostat_client/db/easycontrol/040201.json
@@ -318,10 +318,6 @@
       "hotWaterSystem": {
         "id": "hotWaterSystem",
         "name": "hotWaterSystem"
-      },
-      "openWindowDetectionStatus": {
-        "id": "openWindowDetection/status",
-        "name": "openWindowDetection Status"
       }
     }
   },


### PR DESCRIPTION
This PR moves `openWindowDetectionStatus` from all easycontrol water heater (`dhw1`) to the zone `zn1` circuits.

This reduces unecessary logging in Home Assistant, as the id is not found on the gateway.

Fixes https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues/323.
Above issue also includes a debug scan showing the status only available in `/zones/zn1/openWindowDetection/status`.