### PR TITLE
Make reading of DB files async

### DIFF
--- a/bosch_thermostat_client/db/__init__.py
+++ b/bosch_thermostat_client/db/__init__.py
@@ -9,6 +9,7 @@ from bosch_thermostat_client.const import DEFAULT, FIRMWARE_VERSION
 from bosch_thermostat_client.const.nefit import NEFIT
 from bosch_thermostat_client.const.ivt import (
     CAN,
+    IVT,
     NSC_ICOM_GATEWAY,
     RC300_RC200,
     MBLAN,
@@ -86,3 +87,14 @@ def get_nefit_errors() -> dict:
 def get_easycontrol_errors() -> dict:
     """Get error codes of EASYCONTROL devices."""
     return open_json(os.path.join(MAINPATH, "errorcodes_easycontrol.json"))
+
+
+async def async_get_errors(device_type) -> dict:
+    """Get error codes of all devices."""
+    if device_type == EASYCONTROL:
+        return await asyncio.to_thread(get_easycontrol_errors)
+    elif device_type == NEFIT:
+        return await asyncio.to_thread(get_nefit_errors)
+    elif device_type == IVT:
+        return (await asyncio.to_thread(get_nefit_errors)) | (await asyncio.to_thread(get_ivt_errors))
+    return {}

--- a/bosch_thermostat_client/db/__init__.py
+++ b/bosch_thermostat_client/db/__init__.py
@@ -1,5 +1,6 @@
 """Retrieve standard data."""
 
+import asyncio
 import logging
 import json
 import os
@@ -29,6 +30,10 @@ DEVICE_TYPES = {
 }
 
 
+async def async_open_json(file):
+    return await asyncio.to_thread(open_json, file)
+
+
 def open_json(file):
     """Open json file."""
     try:
@@ -40,13 +45,13 @@ def open_json(file):
     return {}
 
 
-def get_initial_db(device_type):
+async def get_initial_db(device_type):
     filename = os.path.join(MAINPATH, f"db_{device_type}.json")
     """Get initial db. Same for all devices."""
-    return open_json(filename)
+    return await async_open_json(filename)
 
 
-def get_db_of_firmware(device_type, firmware_version):
+async def get_db_of_firmware(device_type, firmware_version):
     """Get db of specific device."""
     if not firmware_version:
         _LOGGER.error("Can't find your fw version.")
@@ -56,7 +61,7 @@ def get_db_of_firmware(device_type, firmware_version):
     )
     filepath = os.path.join(MAINPATH, filename)
     _LOGGER.debug("Attempt to load database from file %s", filepath)
-    _db = open_json(filepath)
+    _db = await async_open_json(filepath)
     return _db if _db.get(FIRMWARE_VERSION) == firmware_version else None
 
 

--- a/bosch_thermostat_client/sensors/notification_easycontrol.py
+++ b/bosch_thermostat_client/sensors/notification_easycontrol.py
@@ -10,7 +10,15 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_easycontrol_errors()
+    errorcodes: dict
+
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        """Notification sensor init."""
+        super().__init__(**kwargs)
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     def get_error_message(self, dcd: str, ccd: str, act: str, fc: str) -> str:
         msg = "Unknown error"

--- a/bosch_thermostat_client/sensors/notification_ivt.py
+++ b/bosch_thermostat_client/sensors/notification_ivt.py
@@ -9,7 +9,15 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_nefit_errors() | get_ivt_errors()
+    errorcodes: dict
+
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        """Notification sensor init."""
+        super().__init__(**kwargs)
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     def process_results(self, result, key=None, return_data=False):
         """Convert multi-level json object to one level object."""

--- a/bosch_thermostat_client/sensors/notification_nefit.py
+++ b/bosch_thermostat_client/sensors/notification_nefit.py
@@ -11,7 +11,7 @@ from bosch_thermostat_client.const import (
 
 
 class NotificationSensor(Sensor):
-    errorcodes = get_nefit_errors()
+    errorcodes: dict
     _allowed_types = "notification"
 
     def __init__(
@@ -42,6 +42,7 @@ class NotificationSensor(Sensor):
             attr_id: {RESULT: {}, URI: path, TYPE: kind},
             "cause": {RESULT: {}, URI: cause_uri, TYPE: kind},
         }
+        self.errorcodes = kwargs.get("errorcodes", {})
 
     @property
     def state(self):

--- a/bosch_thermostat_client/sensors/sensors.py
+++ b/bosch_thermostat_client/sensors/sensors.py
@@ -60,7 +60,7 @@ class Sensors(BoschEntities):
     """Sensors object containing multiple Sensor objects."""
 
     def __init__(
-        self, connector, sensors_db={}, uri_prefix=None, data=None, parent=None
+        self, connector, sensors_db: dict | None = None, uri_prefix=None, data=None, parent=None, errors: dict | None = None
     ):
         """
         Initialize sensors.
@@ -71,7 +71,7 @@ class Sensors(BoschEntities):
         super().__init__(connector.get)
         self._items = {}
 
-        for sensor_id, sensor in sensors_db.items():
+        for sensor_id, sensor in (sensors_db or {}).items():
             if sensor_id not in self._items:
                 kwargs = {
                     "connector": connector,
@@ -87,6 +87,8 @@ class Sensors(BoschEntities):
                     "parent": parent,
                     **sensor,
                 }
+                if sensor_id == NOTIFICATIONS and errors:
+                    kwargs["errorcodes"] = errors
                 SensorClass = get_sensor_class(
                     device_type=connector.device_type, sensor_type=sensor_id
                 )


### PR DESCRIPTION
Should solve one of the warnings reported in https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues/420.

Needed for fixing Home Assistant problems like:

```
2024-06-16 21:44:01.785 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open inside the event loop by custom integration 'bosch' at custom_components/bosch/__init__.py, line 303: await self.gateway.check_connection() (offender: /usr/local/lib/python3.12/site-packages/bosch_thermostat_client/db/__init__.py, line 35: with open(file, "r") as db_file:), please create a bug report at https://github.com/bosch-thermostat/home-assistant-bosch-custom-component/issues
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 223, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 190, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 672, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 639, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 1988, in _run_once
    handle._run()
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 165, in async_setup_component
    result = await _async_setup_component(hass, domain, config)
  File "/usr/src/homeassistant/homeassistant/setup.py", line 447, in _async_setup_component
    await asyncio.gather(
  File "/usr/src/homeassistant/homeassistant/setup.py", line 449, in <genexpr>
    create_eager_task(
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 37, in create_eager_task
    return Task(coro, loop=loop, name=name, eager_start=True)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 742, in async_setup_locked
    await self.async_setup(hass, integration=integration)
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 594, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/bosch/__init__.py", line 149, in async_setup_entry
    _init_status: bool = await gateway_entry.async_init()
  File "/config/custom_components/bosch/__init__.py", line 246, in async_init
    if await self.async_init_bosch():
  File "/config/custom_components/bosch/__init__.py", line 303, in async_init_bosch
    await self.gateway.check_connection()
```