### PR TITLE
Add applianceSupplyTemperature

### DIFF
--- a/bosch_thermostat_client/db/nsc_icom_gateway/040802.json
+++ b/bosch_thermostat_client/db/nsc_icom_gateway/040802.json
@@ -299,6 +299,10 @@
             "id": "/system/sensors/temperatures/supply_t1",
             "name": "Actual supply temp"
         },
+        "appliance_supply": {
+            "id": "/heatSources/applianceSupplyTemperature",
+            "name": "Appliance supply temp"
+        },
         "return": {
             "id": "/system/sensors/temperatures/return",
             "name": "Return temp"


### PR DESCRIPTION
Hi, I have IVT heat pump and use HA integration which works, but it's missing `applianceSupplyTemperature` (warm water from heat pump to the radiators/boiler). The HA integration already contains return temperature (the colder water which returns from radiators/boiler to the heat pump).

My heat pump identifies itself as follows, so I hope I made this PR correct.
```
        {
            "id": "/gateway/versionFirmware",
            "type": "stringValue",
            "writeable": 0,
            "recordable": 0,
            "value": "04.08.02"
        },
        {
            "id": "/gateway/versionHardware",
            "type": "stringValue",
            "writeable": 0,
            "recordable": 0,
            "value": "iCom_Low_NSC_v1"
        },
```