### PR TITLE
add current_temp and eco operationmode to dhw ct200

### DIFF
--- a/bosch_thermostat_client/db/easycontrol/050200.json
+++ b/bosch_thermostat_client/db/easycontrol/050200.json
@@ -252,6 +252,10 @@
       {
         "haname": "performance",
         "boschname": ["ownprogram"]
+      },
+      {
+        "haname": "eco",
+        "boschname": ["eco"]
       }
     ],
     "min_ref": "setpoint1",
@@ -278,6 +282,11 @@
       "switch_points": "value"
     },
     "refs": {
+      "current_temp": {
+        "id": "actualTemp",
+        "name": "Tank temperature",
+        "type": "regular"
+      },
       "operation_mode": {
         "id": "operationMode",
         "name": "Operation mode",


### PR DESCRIPTION
EasyControl CT200 with Monoblock heat pump.
2 small changes in [050200.json](https://github.com/bosch-thermostat/bosch-thermostat-client-python/blob/dev/bosch_thermostat_client/db/easycontrol/050200.json)

- Adding support for current_temperature of the ``water_heater`` in HA. ("id": "/dhwCircuits/dhw1/actualTemp") -> this should also be added to the HA-component?
- Adding new operationMode, eco to map to ``Eco`` in  the state of the ``water_heater`` in HA.