### PR TITLE
Thermal desinfect fix for Bosch CT100

### DIFF
--- a/bosch_thermostat_client/db/nefit/022200.json
+++ b/bosch_thermostat_client/db/nefit/022200.json
@@ -160,21 +160,21 @@
       }
     },
     "sensors": {
-      "thermalDisinfectlastResult": {
-        "id": "thermalDisinfect/lastResult",
-        "name": "thermalDisinfect lastResult"
+      "thermaldesinfectlastResult": {
+        "id": "thermaldesinfect/lastResult",
+        "name": "thermaldesinfect lastResult"
       },
-      "thermalDisinfectstate": {
-        "id": "thermalDisinfect/state",
-        "name": "thermalDisinfect state"
+      "thermaldesinfectstate": {
+        "id": "thermaldesinfect/state",
+        "name": "thermaldesinfect state"
       },
-      "thermalDisinfectlasttime": {
-        "id": "thermalDisinfect/time",
-        "name": "thermalDisinfect time"
+      "thermaldesinfectlasttime": {
+        "id": "thermaldesinfect/time",
+        "name": "thermaldesinfect time"
       },
-      "thermalDisinfectlastweekDay": {
-        "id": "thermalDisinfect/weekDay",
-        "name": "thermalDisinfect weekDay"
+      "thermaldesinfectlastweekDay": {
+        "id": "thermaldesinfect/weekDay",
+        "name": "thermaldesinfect weekDay"
       }
     },
     "switches": {


### PR DESCRIPTION
Thermal desinfect cannot be updated to to incorrect uris:

```
This error originated from a custom integration.

Logger: bosch_thermostat_client.sensors.sensor
Source: custom_components/bosch/__init__.py:415
integration: Bosch thermostat (documentation, issues)
First occurred: 13:25:10 (128 occurrences)
Last logged: 13:56:05

Can't update data for thermalDisinfect lastResult. Trying uri: /dhwCircuits/dhwA/thermalDisinfect/lastResult. Error message: Error requesting data from /dhwCircuits/dhwA/thermalDisinfect/lastResult
Can't update data for thermalDisinfect state. Trying uri: /dhwCircuits/dhwA/thermalDisinfect/state. Error message: Error requesting data from /dhwCircuits/dhwA/thermalDisinfect/state
Can't update data for thermalDisinfect time. Trying uri: /dhwCircuits/dhwA/thermalDisinfect/time. Error message: Error requesting data from /dhwCircuits/dhwA/thermalDisinfect/time
Can't update data for thermalDisinfect weekDay. Trying uri: /dhwCircuits/dhwA/thermalDisinfect/weekDay. Error message: Error requesting data from /dhwCircuits/dhwA/thermalDisinfect/weekDay
```

Updated the uris according to bosch_scan.

![Thermal before](https://github.com/user-attachments/assets/055bbdfe-7d2f-4f12-8d55-46f76efd00da)
![Thermal after](https://github.com/user-attachments/assets/4ebeb256-85d5-4bf5-b277-bc320dd2bb29)


