### PR TITLE
Adding back the contents of PR #49 to have the values for DHW of Actual Water Tank temperature and Eco operation mode.

### DIFF
--- a/bosch_thermostat_client/db/easycontrol/050400.json
+++ b/bosch_thermostat_client/db/easycontrol/050400.json
@@ -253,7 +253,7 @@
         "haname": "performance",
         "boschname": ["ownprogram"]
       },
-	  {
+      {
         "haname": "eco",
         "boschname": ["eco"]
       }
@@ -282,7 +282,7 @@
       "switch_points": "value"
     },
     "refs": {
-	  "current_temp": {
+      "current_temp": {
         "id": "actualTemp",
         "name": "Tank temperature",
         "type": "regular"

--- a/bosch_thermostat_client/db/easycontrol/050400.json
+++ b/bosch_thermostat_client/db/easycontrol/050400.json
@@ -252,6 +252,10 @@
       {
         "haname": "performance",
         "boschname": ["ownprogram"]
+      },
+	  {
+        "haname": "eco",
+        "boschname": ["eco"]
       }
     ],
     "min_ref": "setpoint1",
@@ -278,6 +282,11 @@
       "switch_points": "value"
     },
     "refs": {
+	  "current_temp": {
+        "id": "actualTemp",
+        "name": "Tank temperature",
+        "type": "regular"
+      },
       "operation_mode": {
         "id": "operationMode",
         "name": "Operation mode",


### PR DESCRIPTION
Adding back the contents of PR #49 to have the values for DHW of Actual Water Tank temperature and Eco operation mode.

Initially added by https://github.com/bosch-thermostat/bosch-thermostat-client-python/pull/49 but seems to have been forgotten when the config for firmware version 5.04 was created