### PR TITLE
Code formatting checks by ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,7 @@ build-backend = "pdm.pep517.api"
 version = {from = "bosch_thermostat_client/version.py"}
 [tool.pdm.dev-dependencies]
 dev = [
-    "black>=23.3.0",
-    "isort>=5.12.0",
-    "flake8>=6.0.0",
+    "ruff>=0.8.0",
     "bandit>=1.7.5",
     "pre-commit>=3.2.1",
 ]
@@ -38,30 +36,38 @@ dev = [
 [project.scripts]
 bosch_cli= "bosch_thermostat_client.bosch_cli:cli"
 
-[tool.black]
+[tool.ruff]
 line-length = 88
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | pdm/_vendor
-  | tests/fixtures
-)/
-'''
+exclude = [
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "pdm/_vendor",
+    "tests/fixtures",
+]
 
-[tool.isort]
-profile = "black"
-atomic = true
-filter_files = true
-known_first_party = ["bosch_thermostat_client"]
+[tool.ruff.lint]
+# Enable pycodestyle (E), Pyflakes (F), and isort (I)
+select = ["E", "F", "I"]
+ignore = []
+
+[tool.ruff.lint.isort]
+known-first-party = ["bosch_thermostat_client"]
+
+[tool.ruff.format]
+# Use Black-compatible formatting
+quote-style = "double"
+indent-style = "space"
 
 [tool.pdm.scripts]
 lint = "pre-commit run --all-files"
+format = "ruff format ."
+check = "ruff check ."
+fix = "ruff check --fix ."


### PR DESCRIPTION
Use `ruff` for fast and consistent code formatting:

```
ruff format .          # Format code
ruff check .            # Check for issues
ruff check --fix .    # Fix issues automatically
```

This would generate many changes, I'm not including it the PR yet, so that's the important changes are more visible.