### PR TITLE
Fix JSON keys for thermal desinfect sensor data

### DIFF
--- a/bosch_thermostat_client/db/nefit/022200.json
+++ b/bosch_thermostat_client/db/nefit/022200.json
@@ -161,8 +161,8 @@
     },
     "sensors": {
       "thermaldesinfectlastResult": {
-        "id": "thermaldesinfect/lastResult",
-        "name": "thermaldesinfect lastResult"
+        "id": "thermaldesinfect/lastresult",
+        "name": "thermaldesinfect lastresult"
       },
       "thermaldesinfectstate": {
         "id": "thermaldesinfect/state",
@@ -173,8 +173,8 @@
         "name": "thermaldesinfect time"
       },
       "thermaldesinfectlastweekDay": {
-        "id": "thermaldesinfect/weekDay",
-        "name": "thermaldesinfect weekDay"
+        "id": "thermaldesinfect/weekday",
+        "name": "thermaldesinfect weekday"
       }
     },
     "switches": {


### PR DESCRIPTION
`This error originated from a custom integration.

Logger: bosch_thermostat_client.sensors.sensor
Source: custom_components/bosch/__init__.py:421
integration: Bosch thermostat (documentation, issues)
First occurred: 19:10:03 (348 occurrences)
Last logged: 22:04:28

Can't update data for thermaldesinfect lastResult. Trying uri: /dhwCircuits/dhwA/thermaldesinfect/lastResult. Error message: Error requesting data from /dhwCircuits/dhwA/thermaldesinfect/lastResult
Can't update data for thermaldesinfect weekDay. Trying uri: /dhwCircuits/dhwA/thermaldesinfect/weekDay. Error message: Error requesting data from /dhwCircuits/dhwA/thermaldesinfect/weekDay`

<img width="1234" height="806" alt="2026-03-22 (1)" src="https://github.com/user-attachments/assets/ad36a035-a107-4baa-bf76-e9930e026bcb" />
<img width="1234" height="806" alt="2026-03-22 (2)" src="https://github.com/user-attachments/assets/b992b5c1-129f-4e34-b642-8d652874523f" />
