### PR TITLE
Throttle missing sensor endpoint warnings

### DIFF
--- a/bosch_thermostat_client/sensors/sensor.py
+++ b/bosch_thermostat_client/sensors/sensor.py
@@ -7,6 +7,12 @@ from bosch_thermostat_client.const.ivt import INVALID
 
 _LOGGER = logging.getLogger(__name__)
 
+MISSING_ENDPOINT_ERROR_MARKERS = (
+    "doesn not exist: 404",
+    "does not exist: 404",
+)
+MISSING_ENDPOINT_WARNING_INTERVAL = 60
+
 
 class Sensor(BoschSingleEntity, DeviceClassEntity):
     """Single sensor object."""
@@ -43,6 +49,32 @@ class Sensor(BoschSingleEntity, DeviceClassEntity):
             self._data = data
         else:
             self._data = {attr_id: {RESULT: {}, URI: path, TYPE: kind}}
+        self._missing_endpoint_warning_counts: dict[str, int] = {}
+
+    @staticmethod
+    def _is_missing_endpoint_error(error: Exception) -> bool:
+        error_text = str(error)
+        return any(marker in error_text for marker in MISSING_ENDPOINT_ERROR_MARKERS)
+
+    def _should_log_update_error(self, uri: str, error: Exception) -> bool:
+        if not self._is_missing_endpoint_error(error):
+            self._missing_endpoint_warning_counts.pop(uri, None)
+            return True
+
+        count = self._missing_endpoint_warning_counts.get(uri, 0) + 1
+        self._missing_endpoint_warning_counts[uri] = count
+        return count == 1 or count % MISSING_ENDPOINT_WARNING_INTERVAL == 0
+
+    def _log_sensor_update_error(self, uri: str, error: Exception) -> None:
+        log_level = (
+            logging.WARNING
+            if self._should_log_update_error(uri, error)
+            else logging.DEBUG
+        )
+        _LOGGER.log(
+            log_level,
+            f"Can't update data for {self.name}. Trying uri: {uri}. Error message: {error}",
+        )
 
     @property
     def kind(self) -> str:
@@ -65,8 +97,6 @@ class Sensor(BoschSingleEntity, DeviceClassEntity):
                 self.process_results(result=result, key=self._main_data[ID])
                 self._state = True
             except DeviceException as err:
-                _LOGGER.warning(
-                    f"Can't update data for {self.name}. Trying uri: {item[URI]}. Error message: {err}"
-                )
+                self._log_sensor_update_error(item[URI], err)
                 self._extra_message = f"Can't update data. Error: {err}"
                 self._state = False

--- a/tests/test_update_error_logging.py
+++ b/tests/test_update_error_logging.py
@@ -1,0 +1,58 @@
+"""Tests for repeated update error logging."""
+
+import logging
+
+from bosch_thermostat_client.exceptions import DeviceException
+from bosch_thermostat_client.sensors.sensor import (
+    MISSING_ENDPOINT_WARNING_INTERVAL,
+    Sensor,
+)
+
+
+def _sensor():
+    return Sensor(
+        attr_id="suWiThreshold",
+        path="/heatingCircuits/hc1/suWiThreshold",
+        name="Summer Winter Threshold",
+        connector=None,
+    )
+
+
+def test_missing_endpoint_errors_are_throttled_but_rechecked(caplog):
+    entity = _sensor()
+    error = DeviceException(
+        "URI /heatingCircuits/hc1/suWiThreshold doesn not exist: 404"
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        for _ in range(MISSING_ENDPOINT_WARNING_INTERVAL + 1):
+            entity._log_sensor_update_error(
+                "/heatingCircuits/hc1/suWiThreshold",
+                error,
+            )
+
+    warning_messages = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+
+    assert len(warning_messages) == 2
+    assert "Summer Winter Threshold" in warning_messages[0]
+    assert "suWiThreshold" in warning_messages[0]
+
+
+def test_non_404_errors_are_not_throttled(caplog):
+    entity = _sensor()
+    error = DeviceException("Connection timed out for /heatingCircuits/hc1/suWiThreshold")
+
+    with caplog.at_level(logging.DEBUG):
+        for _ in range(3):
+            entity._log_sensor_update_error(
+                "/heatingCircuits/hc1/suWiThreshold",
+                error,
+            )
+
+    warning_messages = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+
+    assert len(warning_messages) == 3


### PR DESCRIPTION
## Summary

Reduce log spam for Bosch sensor endpoints that currently return HTTP 404, for example `/heatingCircuits/hc1/suWiThreshold` when summer/winter switch mode makes the threshold endpoint unavailable.

## Behavior

- The first missing-endpoint 404 is still logged as a warning.
- Repeated 404s for the same URI are downgraded to debug, with a warning repeated every 60 occurrences.
- The sensor still calls the endpoint on every update, so the value can recover when the gateway exposes the endpoint again.
- Non-404 errors such as timeouts continue to warn every time.

## Why

Some Bosch/IVT gateways make endpoints such as `suWiThreshold` unavailable depending on the current operating mode. This is noisy but not always actionable, and Home Assistant logs can fill with the same warning every update cycle.

## Tests

- `python3 -m compileall -q bosch_thermostat_client tests/test_update_error_logging.py`
- `.venv/bin/python -m pytest -q tests/test_update_error_logging.py`

Result: `2 passed, 1 warning` (existing `datetime.utcnow()` deprecation warning in `sensors/recording.py`).
