### PR TITLE
Preserve HTTP connection failures during startup discovery

### DIFF
--- a/bosch_thermostat_client/circuits/circuit.py
+++ b/bosch_thermostat_client/circuits/circuit.py
@@ -30,7 +30,7 @@ from bosch_thermostat_client.const import (
     DEFAULT_MIN_TEMP,
 )
 from bosch_thermostat_client.helper import BoschSingleEntity
-from bosch_thermostat_client.exceptions import DeviceException
+from bosch_thermostat_client.exceptions import DeviceConnectionError, DeviceException
 from bosch_thermostat_client.sensors import Sensors
 
 from bosch_thermostat_client.operation_mode import OperationModeHelper
@@ -69,14 +69,16 @@ class BasicCircuit(BoschSingleEntity):
         """Give simple json scheme of circuit."""
         return self._db
 
-    async def update_requested_key(self, key):
+    async def update_requested_key(self, key, *, strict_connection=False):
         """Update info about Circuit asynchronously."""
         if key in self._data:
             try:
                 result = await self._connector.get(self._data[key][URI])
                 self.process_results(result, key)
                 self._state = True
-            except DeviceException:
+            except DeviceException as err:
+                if strict_connection and isinstance(err, DeviceConnectionError):
+                    raise
                 self._state = False
 
     @property
@@ -97,7 +99,7 @@ class BasicCircuit(BoschSingleEntity):
 
     async def initialize(self):
         """Check each uri if return json with values."""
-        await self.update_requested_key(STATUS)
+        await self.update_requested_key(STATUS, strict_connection=True)
         await self._switches.initialize(switches=self._db.get(SWITCHES))
 
     @property

--- a/bosch_thermostat_client/circuits/circuits.py
+++ b/bosch_thermostat_client/circuits/circuits.py
@@ -13,7 +13,7 @@ from bosch_thermostat_client.const import (
     SC,
     REFERENCES,
 )
-from bosch_thermostat_client.helper import BoschEntities
+from bosch_thermostat_client.helper import BoschEntities, crawl
 from .nefit import NefitCircuit, NefitHeatingCircuit
 from .ivt import IVTCircuit
 from .easycontrol import EasycontrolCircuit, EasyZoneCircuit
@@ -82,7 +82,9 @@ class Circuits(BoschEntities):
         if db_prefix not in database:
             _LOGGER.debug("Circuit not exist in database %s", db_prefix)
             return None
-        circuits = await self.retrieve_from_module(1, f"/{db_prefix}")
+        circuits = await crawl(
+            f"/{db_prefix}", [], 1, self._get, None, strict_connection=True
+        )
         if self._device_type == EASYCONTROL and PROGRAM_LIST in database:
             self._zone_programs = ZonePrograms(
                 program_uri=database[PROGRAM_LIST], connector=self._connector

--- a/bosch_thermostat_client/connectors/http.py
+++ b/bosch_thermostat_client/connectors/http.py
@@ -5,13 +5,15 @@ import json
 from asyncio import TimeoutError as AsyncTimeout
 from aiohttp.client_exceptions import (
     ClientResponseError,
-    ClientConnectorError,
+    ClientConnectionError,
     ClientError,
 )
 
 from bosch_thermostat_client.const.ivt import HTTP_HEADER, IVT
 from bosch_thermostat_client.const import APP_JSON, GET, PUT
-from bosch_thermostat_client.exceptions import DeviceException, ResponseException
+from bosch_thermostat_client.exceptions import (
+    DeviceConnectionError, DeviceException, ResponseException,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,14 +57,14 @@ class HttpConnector:
                 return await get_response(method.__name__, res)
         except ClientResponseError as err:
             raise DeviceException(f"URI {path} doesn not exist: {err}")
-        except ClientConnectorError as err:
-            raise DeviceException(err)
+        except ClientConnectionError as err:
+            raise DeviceConnectionError(err) from err
         except ResponseException as err:
             raise DeviceException(f"Error requesting data from {path}: {err}")
         except ClientError as err:
             raise DeviceException(f"Error connecting to client {path}: {err}")
-        except AsyncTimeout:
-            raise DeviceException(f"Connection timed out for {path}.")
+        except AsyncTimeout as err:
+            raise DeviceConnectionError(f"Connection timed out for {path}.") from err
 
     def _format_url(self, path):
         """Format URL to make requests to gateway."""

--- a/bosch_thermostat_client/exceptions.py
+++ b/bosch_thermostat_client/exceptions.py
@@ -18,6 +18,10 @@ class DeviceException(BoschException):
     pass
 
 
+class DeviceConnectionError(DeviceException):
+    """HTTP request failed before a complete response was received."""
+
+
 class MsgException(BoschException):
     """
     Invalid request.

--- a/bosch_thermostat_client/gateway/base.py
+++ b/bosch_thermostat_client/gateway/base.py
@@ -41,6 +41,7 @@ from bosch_thermostat_client.db import (
     get_initial_db,
 )
 from bosch_thermostat_client.exceptions import (
+    DeviceConnectionError,
     DeviceException,
     FirmwareException,
     UnknownDevice,
@@ -345,6 +346,8 @@ class BaseGateway:
                 if VALUE in response:
                     self._data[GATEWAY][UUID] = response[VALUE]
         except DeviceException as err:
+            if isinstance(err, DeviceConnectionError):
+                raise
             _LOGGER.debug("Failed to check_connection: %s", err)
         return self.uuid
 

--- a/bosch_thermostat_client/gateway/ivt.py
+++ b/bosch_thermostat_client/gateway/ivt.py
@@ -23,7 +23,7 @@ from bosch_thermostat_client.const.ivt import (
     SYSTEM_INFO,
 )
 from bosch_thermostat_client.encryption import IVTEncryption as Encryption
-from bosch_thermostat_client.exceptions import DeviceException
+from bosch_thermostat_client.exceptions import DeviceConnectionError, DeviceException
 
 from .base import BaseGateway
 
@@ -77,6 +77,8 @@ class IVTGateway(BaseGateway):
                     self._data[GATEWAY][name] = response[VALUE]
                 elif name == SYSTEM_INFO:
                     self._data[GATEWAY][SYSTEM_INFO] = response.get(VALUES, [])
+            except DeviceConnectionError:
+                raise
             except DeviceException as err:
                 _LOGGER.debug("Can't fetch data for update_info %s", err)
                 pass

--- a/bosch_thermostat_client/helper.py
+++ b/bosch_thermostat_client/helper.py
@@ -29,7 +29,7 @@ from bosch_thermostat_client.const import (
 from bosch_thermostat_client.const.easycontrol import STEP_SIZE
 from bosch_thermostat_client.const.ivt import ALLOWED_VALUES, STATE, INVALID
 
-from .exceptions import DeviceException, EncryptionException
+from .exceptions import DeviceConnectionError, DeviceException, EncryptionException
 import base64
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ def get_all_intervals():
     ]
 
 
-async def crawl(url, _list, deep, get, exclude):
+async def crawl(url, _list, deep, get, exclude, *, strict_connection=False):
     """Crawl for Bosch API correct values."""
     try:
         resp = await get(url)
@@ -86,9 +86,14 @@ async def crawl(url, _list, deep, get, exclude):
             if REFERENCES in resp:
                 for uri in resp[REFERENCES]:
                     if ID in uri and deep > 0:
-                        await crawl(uri[ID], _list, deep - 1, get, exclude)
+                        await crawl(
+                            uri[ID], _list, deep - 1, get, exclude,
+                            strict_connection=strict_connection,
+                        )
         return _list
-    except DeviceException:
+    except DeviceException as err:
+        if strict_connection and isinstance(err, DeviceConnectionError):
+            raise
         return _list
 
 

--- a/tests/test_startup_connection.py
+++ b/tests/test_startup_connection.py
@@ -1,0 +1,166 @@
+"""Transport failures must not look like missing gateway capabilities."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from aiohttp import ClientResponseError, ServerDisconnectedError
+
+from bosch_thermostat_client import exceptions
+from bosch_thermostat_client.circuits.circuit import BasicCircuit
+from bosch_thermostat_client.connectors.http import HttpConnector
+from bosch_thermostat_client.const import HC
+from bosch_thermostat_client.gateway.ivt import IVTGateway
+
+# The fallback lets the regression tests execute against the unpatched client.
+ConnectionFailure = getattr(
+    exceptions, "DeviceConnectionError", exceptions.DeviceException
+)
+
+
+class FailingSession:
+    def __init__(self, error):
+        self.error = error
+        self.calls = 0
+
+    def get(self, *args, **kwargs):
+        self.calls += 1
+        raise self.error
+
+    put = get
+
+
+class StartupConnectionTests(unittest.IsolatedAsyncioTestCase):
+    def gateway(self):
+        return IVTGateway("HTTP", "gateway.invalid", "", access_key="00" * 32)
+
+    async def test_timeout_keeps_type_and_cause(self):
+        error = asyncio.TimeoutError()
+        session = FailingSession(error)
+        connector = HttpConnector("gateway.invalid", Mock(), loop=session)
+        with self.assertRaises(exceptions.DeviceException) as caught:
+            await connector.get("/system/info")
+        self.assertEqual(type(caught.exception).__name__, "DeviceConnectionError")
+        self.assertIs(caught.exception.__cause__, error)
+        self.assertEqual(session.calls, 1)
+
+    async def test_disconnect_keeps_type(self):
+        connector = HttpConnector(
+            "gateway.invalid", Mock(), loop=FailingSession(ServerDisconnectedError())
+        )
+        with self.assertRaises(exceptions.DeviceException) as caught:
+            await connector.get("/system/info")
+        self.assertEqual(type(caught.exception).__name__, "DeviceConnectionError")
+
+    async def test_http_status_is_not_connection_failure(self):
+        for status in (401, 404):
+            session = FailingSession(
+                ClientResponseError(
+                    Mock(real_url="http://gateway.invalid/"), (), status=status
+                )
+            )
+            connector = HttpConnector("gateway.invalid", Mock(), loop=session)
+            with self.assertRaises(exceptions.DeviceException) as caught:
+                await connector.get("/missing")
+            self.assertEqual(type(caught.exception), exceptions.DeviceException)
+            self.assertEqual(session.calls, 1)
+
+    async def test_identity_failure_reaches_check_connection(self):
+        gateway = self.gateway()
+        error = ConnectionFailure("Connection timed out")
+        gateway._connector.get = AsyncMock(side_effect=error)
+        with self.assertRaises(ConnectionFailure) as caught:
+            await gateway.check_connection()
+        self.assertIs(caught.exception, error)
+        self.assertEqual(gateway._connector.get.await_count, 1)
+
+    async def test_firmware_timeout_is_not_unknown_firmware(self):
+        gateway = self.gateway()
+        error = ConnectionFailure("Connection timed out")
+
+        async def get(path):
+            if path == "/gateway/versionFirmware":
+                raise error
+            if path == "/system/info":
+                return {"values": [{"Id": "158"}]}
+            return {"value": "EMS"}
+
+        gateway._connector.get = get
+        with self.assertRaises(ConnectionFailure) as caught:
+            await gateway.check_connection()
+        self.assertIs(caught.exception, error)
+
+    async def test_directory_failure_is_not_empty_circuits(self):
+        gateway = self.gateway()
+        gateway._db = {"heatingCircuits": {}}
+        error = ConnectionFailure("Connection timed out")
+        gateway._connector.get = AsyncMock(side_effect=error)
+        with self.assertRaises(ConnectionFailure):
+            await gateway.initialize_circuits(HC)
+
+    async def test_child_directory_failure_is_not_empty_circuits(self):
+        gateway = self.gateway()
+        gateway._db = {"heatingCircuits": {}}
+        gateway._connector.get = AsyncMock(
+            side_effect=[
+                {
+                    "id": "/heatingCircuits",
+                    "references": [{"id": "/heatingCircuits/hc1"}],
+                },
+                ConnectionFailure("Connection timed out"),
+            ]
+        )
+        with self.assertRaises(ConnectionFailure):
+            await gateway.initialize_circuits(HC)
+
+    async def test_legitimate_empty_directory(self):
+        gateway = self.gateway()
+        gateway._db = {"heatingCircuits": {}}
+        gateway._connector.get = AsyncMock(
+            return_value={"id": "/heatingCircuits", "references": []}
+        )
+        self.assertEqual(await gateway.initialize_circuits(HC), [])
+
+    async def test_missing_directory_remains_optional(self):
+        gateway = self.gateway()
+        gateway._db = {"heatingCircuits": {}}
+        gateway._connector.get = AsyncMock(
+            side_effect=exceptions.DeviceException("404")
+        )
+        self.assertEqual(await gateway.initialize_circuits(HC), [])
+
+    async def test_circuit_status_failure_not_inactive(self):
+        connector = SimpleNamespace(
+            get=AsyncMock(side_effect=ConnectionFailure("Connection timed out"))
+        )
+        circuit = BasicCircuit(
+            connector,
+            "/heatingCircuits/hc1",
+            {
+                "heatingCircuits": {
+                    "refs": {"status": {"id": "status", "type": "stringValue"}}
+                },
+            },
+            "heatingCircuits",
+            "EMS",
+        )
+        with self.assertRaises(ConnectionFailure):
+            await circuit.initialize()
+
+    async def test_cancellation_propagates(self):
+        gateway = self.gateway()
+        gateway._connector.get = AsyncMock(side_effect=asyncio.CancelledError())
+        with self.assertRaises(asyncio.CancelledError):
+            await gateway.check_connection()
+
+    async def test_put_is_never_retried(self):
+        session = FailingSession(asyncio.TimeoutError())
+        connector = HttpConnector("gateway.invalid", Mock(), loop=session)
+        with self.assertRaises(exceptions.DeviceException):
+            await connector.put("/heatingCircuits/hc1/operationMode", "auto")
+        self.assertEqual(session.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #67.

An HTTP timeout currently becomes a generic `DeviceException`. `_update_info` catches it and continues, so the missing firmware response is later reported as an unsupported firmware version. Circuit discovery has the same problem: `crawl` returns a partial list, or the status read marks a circuit inactive. A caller cannot tell a failed read from an absent circuit.

This change preserves HTTP timeout/disconnection errors as `DeviceConnectionError`, a `DeviceException` subclass with the original cause. Gateway startup and circuit directory/status discovery let that error reach the caller. The caller can then retry setup rather than accept incomplete discovery.

No retry loop is added. HTTP 401/404 handling, encryption errors, cancellation, ordinary sensor crawling and ongoing circuit updates retain their existing behaviour. PUT is never repeated. XMPP transport is untouched.

## Tests

`python -m unittest discover -s tests -p test_startup_connection.py`

- Patched: 12 passed.
- Same tests against the unmodified base: 5 failures, 2 errors, 5 passed. These reproduce unknown device/firmware, discarded circuits and lost transport error types.
- Guards cover legitimate empty/absent circuit directories, HTTP 401/404, cancellation and one-shot PUT.
- sdist and wheel build succeeded with the repository's PDM build backend.
- New test file passes Ruff. Touched production files have the same 12 existing Ruff findings as the base, with no additional findings. Existing CRLF line endings are preserved.

The legacy AES/HTTP/gateway tests fail collection on both base and patch: stale `Encryption` import, `aiohttp.test_utils` access and missing `asynctest`. This is not a claim that the full legacy suite passes.

## Hardware check and limits

On a KM200 / RC300, the patched client surfaced an actual `/gateway/uuid` timeout as `DeviceConnectionError` with `TimeoutError` preserved, rather than continuing with incomplete identity data. No heating settings were changed.

A separate local bounded-GET startup workaround restored HC1 in HA 2026.8.3 and allowed subsequent state updates. That workaround is not this patch. Applying retries to the whole capability scan hit HA's global startup deadline, which is why this PR propagates failures instead of adding more retries inside the client.

The underlying intermittent HTTP failures are not fixed here. Nor does this claim to fix the XMPP disconnect reports in integration issue #454.
