### PR TITLE
Fix CT200 schedule parsing for timestamps without a timezone

### DIFF
--- a/bosch_thermostat_client/schedule/__init__.py
+++ b/bosch_thermostat_client/schedule/__init__.py
@@ -42,6 +42,9 @@ from bosch_thermostat_client.exceptions import DeviceException
 
 _LOGGER = logging.getLogger(__name__)
 
+_CT200_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+_CT200_NAIVE_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
 
 class Schedule:
     """Scheduler logic."""
@@ -262,7 +265,19 @@ class Schedule:
             return (DAYS_INT.index(day), switchpoints[self._time_key])
 
         if self._time:
-            bosch_date = datetime.strptime(self._time[0:25], self._date_format)
+            try:
+                bosch_date = datetime.strptime(self._time[0:25], self._date_format)
+            except ValueError as err:
+                if self._date_format != _CT200_DATE_FORMAT:
+                    raise
+                try:
+                    bosch_date = datetime.strptime(
+                        self._time, _CT200_NAIVE_DATE_FORMAT
+                    )
+                except ValueError:
+                    raise err
+                if bosch_date.strftime(_CT200_NAIVE_DATE_FORMAT) != self._time:
+                    raise err
             day_of_week = DAYS_INT[bosch_date.weekday()]
             if self._switch_points:
                 switch_points = self._switch_points.copy()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,90 @@
+"""Schedule timestamp parsing tests."""
+from types import SimpleNamespace
+
+import pytest
+
+from bosch_thermostat_client.const import ABSOLUTE
+from bosch_thermostat_client.const.ivt import CAN
+from bosch_thermostat_client.schedule import Schedule
+
+CT200_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def make_schedule(date_format=CT200_DATE_FORMAT):
+    """Create a CT200 schedule with distinct Sunday and Monday values."""
+    schedule = Schedule(
+        connector=None,
+        circuit_type="dhwCircuits",
+        circuit_name="dhw1",
+        current_time=None,
+        bus_type=CAN,
+        db={
+            "schedule": {
+                "program": "/dhwCircuits/{}/programs/{}/week",
+                "key_day": "d",
+                "key_setpoint": "dhw",
+                "key_time": "t",
+                "switch_points": "value",
+            },
+            "refs": {},
+        },
+        op_mode=SimpleNamespace(),
+        date_format=date_format,
+    )
+    schedule._switchprogram_mode = ABSOLUTE
+    schedule._switch_points = [
+        {"d": "Su", "dhw": "17.0", "t": 1380},
+        {"d": "Mo", "dhw": "21.0", "t": 0},
+    ]
+    return schedule
+
+
+def test_ct200_naive_timestamp_uses_device_local_weekday():
+    schedule = make_schedule()
+    schedule._time = "2026-08-24T00:30:00"
+
+    assert schedule.get_temp_in_schedule()["temp"] == 21.0
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    ["2026-08-24T00:30:00+02:00", "2026-08-24T00:30:00Z"],
+)
+def test_ct200_offset_timestamps_keep_existing_behavior(timestamp):
+    schedule = make_schedule()
+    schedule._time = timestamp
+
+    assert schedule.get_temp_in_schedule()["temp"] == 21.0
+
+
+def test_non_ct200_date_format_keeps_existing_parser():
+    schedule = make_schedule("%Y-%m-%dT%H:%M:%S")
+    schedule._time = "2026-08-24T00:30:00"
+
+    assert schedule.get_temp_in_schedule()["temp"] == 21.0
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "not-a-date",
+        "2026-08-24 00:30:00",
+        "2026-8-24T00:30:00",
+        "2026-02-30T00:30:00",
+        "2026-08-24T00:30:00+invalid",
+    ],
+)
+def test_malformed_ct200_timestamp_still_raises_value_error(timestamp):
+    schedule = make_schedule()
+    schedule._time = timestamp
+
+    with pytest.raises(ValueError):
+        schedule.get_temp_in_schedule()
+
+
+def test_non_ct200_format_does_not_accept_ct200_naive_timestamp():
+    schedule = make_schedule("%Y-%m-%d")
+    schedule._time = "2026-08-24T00:30:00"
+
+    with pytest.raises(ValueError):
+        schedule.get_temp_in_schedule()


### PR DESCRIPTION
Fixes #69.

CT200 firmware `05.04.00` can return a timestamp such as `2026-08-23T12:57:18`. Schedule evaluation currently raises `ValueError` because the configured format requires a timezone. Accept the timezone-less form for this format while preserving device-local schedule selection and existing parsing for other formats.

Regression tests cover timezone-less, offset-bearing and `Z` timestamps, weekday selection around midnight, and malformed input. This change addresses the parser exception only; it does not claim to fix XMPP connection failures.

Validation on Python 3.14:

- Original upstream `bc27c33`: new schedule tests produce `1 failed, 9 passed`, with the timezone-less timestamp reproducing the reported `ValueError`.
- Patched code: `python -m pytest -q tests/test_schedule.py tests/test_startup_connection.py tests/test_update_error_logging.py` produces `24 passed`.
- `ruff check tests/test_schedule.py` and `git diff --check` pass. Existing source-file lint findings remain outside this change.
- The live XMPP test module requires gateway authentication and was not successfully validated. The full hardware-dependent suite is not claimed as passing.
